### PR TITLE
Minimum viable infrastructure as code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+*tfstate*
+*kubeconfig*

--- a/control/bot.tf
+++ b/control/bot.tf
@@ -1,0 +1,62 @@
+resource "kubernetes_deployment" "bot" {
+  metadata {
+    namespace   = var.control_namespace
+    name        = "micro-bot"
+    labels      = merge(local.common_labels, { "name" = "micro-bot" })
+    annotations = merge(local.common_annotations, { "name" = "go.micro.bot" })
+  }
+  spec {
+    replicas = var.replicas
+    selector {
+      match_labels = merge(local.common_labels, { "name" = "micro-bot" })
+    }
+    template {
+      metadata {
+        labels = merge(local.common_labels, { "name" = "micro-bot" })
+      }
+      spec {
+        container {
+          name = "micro-bot"
+
+          command = [
+            "/micro",
+            "bot",
+            "--inputs=slack"
+          ]
+
+          image             = var.micro_image
+          image_pull_policy = var.image_pull_policy
+
+          dynamic "env" {
+            for_each = local.common_env_vars
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+          env {
+            name = "MICRO_SLACK_TOKEN"
+            value_from {
+              secret_key_ref {
+                name = "micro-slack"
+                key  = "token"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  depends_on = [kubernetes_secret.bot_slack_token]
+}
+
+resource "kubernetes_secret" "bot_slack_token" {
+  metadata {
+    namespace = var.control_namespace
+    name      = "micro-slack"
+  }
+  type = "Opaque"
+  data = {
+    "token" = var.slack_token
+  }
+}

--- a/control/control.tf
+++ b/control/control.tf
@@ -1,0 +1,24 @@
+resource "kubernetes_namespace" "control" {
+  metadata {
+    name = var.control_namespace
+  }
+}
+
+locals {
+  common_labels = {
+    "micro" = "runtime"
+  }
+  common_annotations = {
+    "version" = "latest"
+    "source"  = "github.com/micro/micro"
+    "owner"   = "micro"
+    "group"   = "micro"
+  }
+  common_env_vars = {
+    "MICRO_LOG_LEVEL"        = "DEBUG"
+    "MICRO_BROKER"           = "nats"
+    "MICRO_BROKER_ADDRESS"   = "nats-cluster.${var.resource_namespace}.svc"
+    "MICRO_REGISTRY"         = "etcd"
+    "MICRO_REGISTRY_ADDRESS" = "etcd-cluster.${var.resource_namespace}.svc"
+  }
+}

--- a/control/network.tf
+++ b/control/network.tf
@@ -1,0 +1,109 @@
+resource "kubernetes_deployment" "network" {
+  metadata {
+    namespace   = var.control_namespace
+    name        = "micro-network"
+    labels      = merge(local.common_labels, { "name" = "micro-network" })
+    annotations = merge(local.common_annotations, { "name" = "go.micro.network" })
+  }
+  spec {
+    replicas = var.replicas
+    selector {
+      match_labels = merge(local.common_labels, { "name" = "micro-network" })
+    }
+    template {
+      metadata {
+        labels = merge(local.common_labels, { "name" = "micro-network" })
+      }
+      spec {
+        container {
+          name = "micro-network"
+
+          command = [
+            "/micro",
+            "network",
+          ]
+
+          image             = var.micro_image
+          image_pull_policy = var.image_pull_policy
+
+          dynamic "env" {
+            for_each = local.common_env_vars
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+          env {
+            name  = "MICRO_SERVER_ADDRESS"
+            value = "0.0.0.0:8080"
+          }
+          env {
+            name  = "MICRO_NETWORK_NODES"
+            value = "network.${var.domain_name}"
+          }
+
+          port {
+            container_port = 8080
+            name           = "service-port"
+          }
+          port {
+            container_port = 8085
+            name           = "network-port"
+          }
+        }
+        affinity {
+          pod_anti_affinity {
+            preferred_during_scheduling_ignored_during_execution {
+              weight = 100
+              pod_affinity_term {
+                label_selector {
+                  match_expressions {
+                    key      = "name"
+                    operator = "In"
+                    values   = ["micro-network"]
+                  }
+                }
+                topology_key = "kubernetes.io/hostname"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "network" {
+  metadata {
+    namespace = var.control_namespace
+    name      = "micro-network"
+    labels    = merge(local.common_labels, { "name" = "micro-network" })
+  }
+  spec {
+    type     = "NodePort"
+    selector = merge(local.common_labels, { "name" = "micro-network" })
+    port {
+      name      = "network"
+      port      = 8085
+      node_port = 30038
+      protocol  = "UDP"
+    }
+  }
+}
+
+resource "kubernetes_service" "gateway" {
+  metadata {
+    namespace = var.control_namespace
+    name      = "micro-gateway"
+    labels    = merge(local.common_labels, { "name" = "micro-gateway" })
+  }
+  spec {
+    type     = "ClusterIP"
+    selector = merge(local.common_labels, { "name" = "micro-network" })
+    port {
+      name     = "service"
+      port     = 8080
+      protocol = "TCP"
+    }
+  }
+}

--- a/control/provider.tf
+++ b/control/provider.tf
@@ -1,0 +1,4 @@
+provider "kubernetes" {
+  version = "~> 1.10"
+  # No config, it's expected to be provided when the module is called.
+}

--- a/control/variables.tf
+++ b/control/variables.tf
@@ -1,0 +1,33 @@
+variable "control_namespace" {
+  description = "Control plane Namespace"
+  default     = "control"
+}
+
+variable "resource_namespace" {
+  description = "Shared resources kubernetes namespace"
+  default     = "resource"
+}
+
+variable "replicas" {
+  description = "Replicas of control plane deployments"
+  default     = 1
+}
+
+variable "micro_image" {
+  description = "Micro docker image"
+  default     = "micro/micro"
+}
+
+variable "image_pull_policy" {
+  description = "Kubernetes image pull policy for control plane deployments"
+  default     = "Always"
+}
+
+variable "domain_name" {
+  description = "Domain name of the platform (e.g. micro.mu)"
+  default     = "micro.mu"
+}
+
+variable "slack_token" {
+  description = "Slack token for micro bot"
+}

--- a/e2etest-lon1-do.tf
+++ b/e2etest-lon1-do.tf
@@ -1,0 +1,60 @@
+# This file spins up micro in digitalocean, as a test of the infrastructure as code.
+
+# Instatiate a specific digitalocean provider per module.
+provider "digitalocean" {
+  alias = "e2etest"
+  token = var.do_token
+}
+
+module "e2etest_k8s" {
+  source = "./infrastructure/kubernetes/do"
+  providers = {
+    digitalocean = digitalocean.e2etest
+  }
+
+  region      = "lon1"
+  k8s_version = "1.16"
+  node_count  = 3
+  node_cpu    = [2]
+  node_memory = [4096]
+}
+
+data "digitalocean_kubernetes_cluster" "e2etest" {
+  provider = digitalocean.e2etest
+  name     = module.e2etest_k8s.cluster_name
+}
+
+provider "kubernetes" {
+  alias            = "e2etest"
+  load_config_file = false
+  host             = data.digitalocean_kubernetes_cluster.e2etest.endpoint
+  token            = data.digitalocean_kubernetes_cluster.e2etest.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    data.digitalocean_kubernetes_cluster.e2etest.kube_config[0].cluster_ca_certificate
+  )
+}
+
+module "e2etest_resource" {
+  source = "./resource"
+  providers = {
+    kubernetes = kubernetes.e2etest
+  }
+
+  resource_namespace = "e2eresource"
+}
+
+module "e2etest_control" {
+  source = "./control"
+  providers = {
+    kubernetes = kubernetes.e2etest
+  }
+
+  control_namespace  = "e2econtrol"
+  resource_namespace = "e2eresource"
+  slack_token        = var.slack_token
+}
+
+resource "local_file" "e2etest_kubeconfig" {
+  content  = data.digitalocean_kubernetes_cluster.e2etest.kube_config[0].raw_config
+  filename = "/tmp/e2ekubeconfig"
+}

--- a/infrastructure/kubernetes/aws/kubernetes.tf
+++ b/infrastructure/kubernetes/aws/kubernetes.tf
@@ -1,0 +1,93 @@
+locals {
+  cluster_name = "micro-${var.region}-${random_id.k8s_name.hex}"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "random_id" "k8s_name" {
+  byte_length = 4
+}
+
+module vpc {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.6.0"
+
+  name                 = "micro-${random_id.k8s_name.hex}"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
+  }
+}
+
+resource "aws_security_group" "nodes_mgmt" {
+  name_prefix = "micro-mgmt-${random_id.k8s_name.hex}"
+  vpc_id      = module.vpc.vpc_id
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "10.0.0.0/8",
+      "172.16.0.0/12",
+      "192.168.0.0/16",
+    ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "8.1.0"
+
+  cluster_name    = local.cluster_name
+  cluster_version = var.k8s_version
+  subnets         = module.vpc.private_subnets
+  vpc_id          = module.vpc.vpc_id
+
+  tags = {
+    Environment = "micro-aws-${var.region}"
+  }
+  worker_groups = [{
+    name                          = "nodes"
+    instance_type                 = var.node_flavor
+    asg_desired_capacity          = var.node_count
+    additional_security_group_ids = [aws_security_group.nodes_mgmt.id]
+  }]
+}
+
+# Cluster ID is output for later use to configure a kubernetes provider
+output "cluster_name" {
+  value = module.eks.cluster_id
+}

--- a/infrastructure/kubernetes/aws/provider.tf
+++ b/infrastructure/kubernetes/aws/provider.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+provider "aws" {
+  region  = var.region
+  version = "~> 2.45"
+}
+
+provider "random" {
+  version = "~> 2.2"
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}

--- a/infrastructure/kubernetes/aws/variables.tf
+++ b/infrastructure/kubernetes/aws/variables.tf
@@ -1,0 +1,19 @@
+variable "region" {
+  description = "AWS Region"
+  default     = "eu-west-2"
+}
+
+variable "k8s_version" {
+  description = "Major+minor Kubernetes version (e.g. 1.15)"
+  default     = "1.14"
+}
+
+variable "node_count" {
+  description = "Number of nodes in the default node pool"
+  default     = 3
+}
+
+variable "node_flavor" {
+  description = "Acceptable vCPU values for nodes"
+  default     = "t2.small"
+}

--- a/infrastructure/kubernetes/do/kubernetes.tf
+++ b/infrastructure/kubernetes/do/kubernetes.tf
@@ -1,0 +1,48 @@
+data "digitalocean_kubernetes_versions" "k8s_versions" {
+  version_prefix = "${var.k8s_version}."
+}
+
+data "digitalocean_sizes" "valid_sizes" {
+  filter {
+    key    = "vcpus"
+    values = var.node_cpu
+  }
+
+  filter {
+    key    = "memory"
+    values = var.node_memory
+  }
+
+  filter {
+    key    = "regions"
+    values = [var.region]
+  }
+
+  sort {
+    key       = "price_monthly"
+    direction = "asc"
+  }
+}
+
+resource "random_id" "k8s_name" {
+  byte_length = 4
+}
+
+resource "digitalocean_kubernetes_cluster" "k8s_cluster" {
+  name    = "micro-${var.region}-${random_id.k8s_name.hex}"
+  region  = var.region
+  version = data.digitalocean_kubernetes_versions.k8s_versions.latest_version
+
+  node_pool {
+    name       = "default-${random_id.k8s_name.hex}"
+    node_count = var.node_count
+
+    # This fails on apply if there were no valid sizes found
+    size = length(data.digitalocean_sizes.valid_sizes.sizes) > 0 ? element(data.digitalocean_sizes.valid_sizes.sizes, 0).slug : null
+  }
+}
+
+# Cluster name is output for later use to configure a kubernetes provider
+output "cluster_name" {
+  value = digitalocean_kubernetes_cluster.k8s_cluster.name
+}

--- a/infrastructure/kubernetes/do/provider.tf
+++ b/infrastructure/kubernetes/do/provider.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+# A DigitalOcean personal access token
+variable "do_token" {
+  description = "Your DigitalOcean personal access token"
+  default     = ""
+}
+
+provider "digitalocean" {
+  token   = var.do_token
+  version = "~> 1.12"
+}
+
+provider "random" {
+  version = "~> 2.2"
+}

--- a/infrastructure/kubernetes/do/variables.tf
+++ b/infrastructure/kubernetes/do/variables.tf
@@ -1,0 +1,24 @@
+variable "region" {
+  description = "DigitalOcean region"
+  default     = "lon1"
+}
+
+variable "k8s_version" {
+  description = "Major+minor Kubernetes version (e.g. 1.16)"
+  default     = "1.16"
+}
+
+variable "node_count" {
+  description = "Number of nodes in the default node pool"
+  default     = 3
+}
+
+variable "node_cpu" {
+  description = "Acceptable vCPU values for nodes"
+  default     = [2]
+}
+
+variable "node_memory" {
+  description = "Acceptable memory values for nodes (MiB)"
+  default     = [4096]
+}

--- a/resource/etcd.tf
+++ b/resource/etcd.tf
@@ -1,0 +1,171 @@
+resource "kubernetes_service" "etcd" {
+  metadata {
+    name      = "etcd"
+    namespace = var.resource_namespace
+    annotations = {
+      # Deprecated but still around
+      "service.alpha.kubernetes.io/tolerate-unready-endpoints" = "true"
+    }
+  }
+  spec {
+    port {
+      port = 2379
+      name = "client"
+    }
+    port {
+      port = 2380
+      name = "peer"
+    }
+    cluster_ip = "None"
+    selector = {
+      "component" = "etcd"
+    }
+    publish_not_ready_addresses = true
+  }
+}
+
+resource "kubernetes_service" "etcd_cluster" {
+  metadata {
+    name      = "etcd-cluster"
+    namespace = var.resource_namespace
+    labels = {
+      "component" = "etcd"
+    }
+  }
+  spec {
+    selector = {
+      "component" = "etcd"
+    }
+    port {
+      name        = "client"
+      port        = 2379
+      target_port = "client"
+    }
+  }
+}
+
+resource "kubernetes_pod_disruption_budget" "etcd" {
+  metadata {
+    name      = "etcd"
+    namespace = var.resource_namespace
+  }
+  spec {
+    max_unavailable = "1"
+    selector {
+      match_labels = {
+        "component" = "etcd"
+      }
+    }
+  }
+}
+
+locals {
+  etcd_initial_cluster_string = join(",", formatlist("etcd-%s=http://etcd-%s.etcd:2380", ["0", "1", "2"], ["0", "1", "2"]))
+}
+
+resource "random_id" "etcd_cluster_token" {
+  byte_length = 16
+}
+
+resource "kubernetes_stateful_set" "etcd" {
+  metadata {
+    name      = "etcd"
+    namespace = var.resource_namespace
+    labels = {
+      "component" = "etcd"
+    }
+  }
+  spec {
+    service_name = "etcd"
+    replicas     = 3
+    update_strategy {
+      type = "RollingUpdate"
+    }
+    selector {
+      match_labels = {
+        "component" = "etcd"
+      }
+    }
+    template {
+      metadata {
+        name = "etcd"
+        labels = {
+          "component" = "etcd"
+        }
+      }
+      spec {
+        container {
+          name  = "etcd"
+          image = var.etcd_image
+          command = [
+            "/bin/sh",
+            "-ecx",
+            <<-ETCDLAUNCHER
+            exec etcd --name $${POD_NAME} \
+              --listen-peer-urls=http://$${POD_IP}:2380 \
+              --listen-client-urls=http://$${POD_IP}:2379,http://127.0.0.1:2379 \
+              --advertise-client-urls=http://$${POD_NAME}.etcd.$${POD_NAMESPACE}.svc:2379 \
+              --initial-advertise-peer-urls=http://$${POD_NAME}.etcd.$${POD_NAMESPACE}.svc:2380 \
+              --initial-cluster-token=${random_id.etcd_cluster_token.hex} \
+              --initial-cluster=${local.etcd_initial_cluster_string} \
+              --data-dir=/var/run/etcd/default.etcd
+            ETCDLAUNCHER
+          ]
+          env {
+            name = "POD_IP"
+            value_from {
+              field_ref {
+                field_path = "status.podIP"
+              }
+            }
+          }
+          env {
+            name = "POD_NAME"
+            value_from {
+              field_ref {
+                field_path = "metadata.name"
+              }
+            }
+          }
+          env {
+            name = "POD_NAMESPACE"
+            value_from {
+              field_ref {
+                field_path = "metadata.namespace"
+              }
+            }
+          }
+          env {
+            name  = "ETCDCTL_API"
+            value = "3"
+          }
+          port {
+            container_port = 2379
+            name           = "client"
+          }
+          port {
+            container_port = 2380
+            name           = "peer"
+          }
+          volume_mount {
+            name       = "etcd-data"
+            mount_path = "/var/run/etcd"
+          }
+        }
+      }
+    }
+    volume_claim_template {
+      metadata {
+        name = "etcd-data"
+      }
+      spec {
+        access_modes = ["ReadWriteOnce"]
+        resources {
+          requests = {
+            "storage" = "10Gi"
+          }
+        }
+      }
+    }
+  }
+}

--- a/resource/nats.tf
+++ b/resource/nats.tf
@@ -1,0 +1,209 @@
+# Based off https://github.com/nats-io/k8s/blob/53bfb34f36bfcd08a9434c558b6b77fa9081118a/nats-server/simple-nats.yml
+
+resource "kubernetes_config_map" "nats_server" {
+  metadata {
+    namespace = var.resource_namespace
+    name      = "nats-config"
+  }
+  data = {
+    "nats.conf" = <<-NATSCONF
+      pid_file: "/var/run/nats/nats.pid"
+      http: 8222
+
+      cluster {
+        port: 6222
+        routes [
+          nats://nats-0.nats.${var.resource_namespace}.svc:6222
+          nats://nats-1.nats.${var.resource_namespace}.svc:6222
+          nats://nats-2.nats.${var.resource_namespace}.svc:6222
+        ]
+
+        cluster_advertise: $CLUSTER_ADVERTISE
+        connect_retries: 30
+      }
+    NATSCONF
+  }
+}
+
+locals {
+  nats_ports = {
+    "client"    = 4222,
+    "cluster"   = 6222,
+    "monitor"   = 8222,
+    "metrics"   = 7777,
+    "leafnodes" = 7422,
+    "gateways"  = 7522,
+  }
+}
+
+resource "kubernetes_service" "nats" {
+  metadata {
+    namespace = var.resource_namespace
+    name      = "nats"
+    labels = {
+      "app" = "nats"
+    }
+  }
+  spec {
+    selector = {
+      "app" = "nats"
+    }
+    cluster_ip = "None"
+    dynamic "port" {
+      for_each = local.nats_ports
+      content {
+        name = port.key
+        port = port.value
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "nats_cluster" {
+  metadata {
+    namespace = var.resource_namespace
+    name      = "nats-cluster"
+    labels = {
+      "app" = "nats"
+    }
+  }
+  spec {
+    selector = {
+      "app" = "nats"
+    }
+    port {
+      name        = "client"
+      port        = lookup(local.nats_ports, "client", 4222)
+      target_port = "client"
+    }
+  }
+}
+
+resource "kubernetes_stateful_set" "nats" {
+  metadata {
+    namespace = var.resource_namespace
+    name      = "nats"
+    labels = {
+      "app" = "nats"
+    }
+  }
+  spec {
+    replicas     = 3
+    service_name = "nats"
+    selector {
+      match_labels = {
+        "app" = "nats"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          "app" = "nats"
+        }
+      }
+      spec {
+        volume {
+          name = "config-volume"
+          config_map {
+            default_mode = "0644"
+            name         = kubernetes_config_map.nats_server.metadata.0.name
+          }
+        }
+        volume {
+          name = "pid"
+          empty_dir {}
+        }
+        share_process_namespace          = true
+        termination_grace_period_seconds = 60
+        container {
+          name  = "nats"
+          image = var.nats_image
+          dynamic "port" {
+            for_each = local.nats_ports
+            content {
+              name           = port.key
+              container_port = port.value
+            }
+          }
+          command = [
+            "nats-server",
+            "--config",
+            "/etc/nats-config/nats.conf"
+          ]
+          env {
+            name = "POD_NAME"
+            value_from {
+              field_ref {
+                field_path = "metadata.name"
+              }
+            }
+          }
+          env {
+            name = "POD_NAMESPACE"
+            value_from {
+              field_ref {
+                field_path = "metadata.namespace"
+              }
+            }
+          }
+          env {
+            name  = "CLUSTER_ADVERTISE"
+            value = "$(POD_NAME).nats.$(POD_NAMESPACE).svc"
+          }
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/nats-config"
+          }
+          volume_mount {
+            name       = "pid"
+            mount_path = "/var/run/nats"
+          }
+          liveness_probe {
+            http_get {
+              path = "/"
+              port = lookup(local.nats_ports, "monitor", 8222)
+            }
+            initial_delay_seconds = 10
+            timeout_seconds       = 5
+          }
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = lookup(local.nats_ports, "monitor", 8222)
+            }
+            initial_delay_seconds = 10
+            timeout_seconds       = 5
+          }
+          lifecycle {
+            pre_stop {
+              exec {
+                command = [
+                  "/bin/sh", "-c", "/nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+    update_strategy {
+      type = "RollingUpdate"
+    }
+  }
+  depends_on = [kubernetes_config_map.nats_server]
+}
+
+resource "kubernetes_pod_disruption_budget" "nats" {
+  metadata {
+    name      = "nats"
+    namespace = var.resource_namespace
+  }
+  spec {
+    max_unavailable = "1"
+    selector {
+      match_labels = {
+        "app" = "nats"
+      }
+    }
+  }
+}

--- a/resource/provider.tf
+++ b/resource/provider.tf
@@ -1,0 +1,8 @@
+provider "kubernetes" {
+  version = "~> 1.10"
+  # No config, it's expected to be provided when the module is called.
+}
+
+provider "random" {
+  version = "~> 2.2"
+}

--- a/resource/resource.tf
+++ b/resource/resource.tf
@@ -1,0 +1,9 @@
+resource "kubernetes_namespace" "resource" {
+  metadata {
+    name = var.resource_namespace
+  }
+}
+
+locals {
+
+}

--- a/resource/variables.tf
+++ b/resource/variables.tf
@@ -1,0 +1,29 @@
+variable "resource_namespace" {
+  description = "Shared resources kubernetes namespace"
+  default     = "resource"
+}
+
+variable "domain_name" {
+  description = "Domain name of the platform (e.g. micro.mu)"
+  default     = "micro.mu"
+}
+
+variable "image_pull_policy" {
+  description = "Kubernetes image pull policy for control plane deployments"
+  default     = "Always"
+}
+
+variable "micro_image" {
+  description = "Micro docker image"
+  default     = "micro/micro"
+}
+
+variable "etcd_image" {
+  description = "etcd docker image"
+  default     = "gcr.io/etcd-development/etcd:v3.3.18"
+}
+
+variable "nats_image" {
+  description = "nats-io docker image"
+  default     = "nats:2.1.0-alpine3.10"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,7 @@
+variable "do_token" {
+  description = "DigitalOcean Personal Access Token"
+}
+
+variable "slack_token" {
+  description = "Slack token for Micro Bot"
+}


### PR DESCRIPTION
This contains code for spinning up Kubernetes on DigitalOcean or AWS,
A micro control plane and shared etcd and NATS infrastructure.

An example is in the e2etest-lon1-do.tf, which spins up a new environment
in DigitalOcean's lon1 region